### PR TITLE
Fix keyboard issue encountered when starting a random new game

### DIFF
--- a/src/components/Keypad/index.tsx
+++ b/src/components/Keypad/index.tsx
@@ -54,7 +54,7 @@ export default function Keypad ({
         }
       }
     },
-    [currentColumnIndex]
+    [currentColumnIndex, status.complete]
   )
   useEffect(() => {
     document.addEventListener('keydown', handleKeyboardInput)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This change addresses a bug where users could not use the keyboard as an input device until interacting with the on-screen keyboard after generating a new, random game. The fix was to ensure that `status.complete` was part of the relevant handler's `useCallback` dependency array.

* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Other information**:

